### PR TITLE
This plugin leaves behind database entries that should be cleaned up

### DIFF
--- a/script.php
+++ b/script.php
@@ -26,7 +26,32 @@ class  languagehotfixInstallerScript
         // Display a success message with the path information
         JFactory::getApplication()->enqueueMessage("LanguageHelper.php replaced successfully. New file placed at: $targetFile", 'message');
 
+        // Remove this plugin to leave no trace
+        $this->uninstallPlugin();
+
         return true;
     }
+
+    private function uninstallPlugin()
+    {
+        $plugins = $this->findThisPlugin();
+        foreach ($plugins as $plugin) {
+            \JInstaller::getInstance()->uninstall($plugin->type, $plugin->extension_id);
+        }
+    }
+
+    private function findThisPlugin()
+    {
+        $db = \JFactory::getDbo();
+        $query = $db->getQuery(true)
+            ->select('extension_id')
+            ->select('type')
+            ->from('#__extensions')
+            ->where("`element` = 'languagehotfix'")
+            ->where("`type` = 'file'");
+
+        $db->setQuery($query);
+
+        return $db->loadObjectList();
+    }
 }
-?>


### PR DESCRIPTION
This PR when merged and released will clean up any rows leftover in the database when installing this plugin, or if the plugin has already been used, it can be reinstalled to clean up the db rows with no harm. 

Without this change a record is left in the database forever! There is no need for that. 


![ScreenShot-2023-11-30-15 43 03](https://github.com/TLWebdesign/Joomla-3.10.12-languagehelper-hotfix/assets/400092/bc5db139-e3b4-4f83-9c9a-a09dea265186)
